### PR TITLE
bump hwloc to 1.11.3, add missing hwloc easyconfig file

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.3-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = '1.11.3'
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'PGI', 'version': '16.3-GCC-4.9.3-2.25'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+# numactl is a direct dependency of PGI
+configopts = "--enable-libnuma=$EBROOTNUMACTL"
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-1.10.2-PGI-16.3-GCC-4.9.3-2.25.eb
@@ -18,7 +18,7 @@ configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
 configopts += '--disable-dlopen '  # statically link component, don't do dynamic loading
 configopts += '--with-cxxrtlib="-lgcc_s -lstdc++"' # for vt-mpi-unify
 
-dependencies = [('hwloc', '1.11.2')]
+dependencies = [('hwloc', '1.11.3')]
 
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]


### PR DESCRIPTION
@bartoldeman this PR adds the missing easyconfig file for `hwloc` in https://github.com/hpcugent/easybuild-easyconfigs/pull/2899

I also bumped to the latest version of `hwloc`, let me know if that's OK.
